### PR TITLE
Feature: add Javascript endpoints and systemd service example

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
+	"encoding/json"
 	"github.com/gin-gonic/gin"
 	proxyproto "github.com/pires/go-proxyproto"
 )
@@ -130,6 +130,7 @@ func mainHandler(c *gin.Context) {
 	}
 
 	wantsJSON := len(fields) >= 2 && fields[1] == "json"
+	wantsJS := len(fields) >= 2 && fields[1] == "js"
 
 	switch fields[0] {
 	case "":
@@ -147,6 +148,10 @@ func mainHandler(c *gin.Context) {
 	case "all":
 		if wantsJSON {
 			c.JSON(200, c.Keys)
+		} else if wantsJS {
+			c.Writer.Header().Set("Content-Type", "application/javascript")
+			response, _ := json.Marshal(c.Keys)
+			c.String(200, "ifconfig_io = %v\n", string(response))
 		} else {
 			c.String(200, "%v", c.Keys)
 		}
@@ -190,6 +195,7 @@ func main() {
 		r.GET(fmt.Sprintf("/%s", route), mainHandler)
 		r.GET(fmt.Sprintf("/%s.json", route), mainHandler)
 	}
+	r.GET("/all.js", mainHandler)
 	r.GET("/", mainHandler)
 
 	errc := make(chan error)

--- a/web-service.systemd
+++ b/web-service.systemd
@@ -1,0 +1,24 @@
+[Unit]
+Description=ifconfig.io web service
+ConditionPathExists=/opt/ifconfig.io
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+Environment="GIN_MODE=release"
+Restart=on-failure
+RestartSec=10
+startLimitIntervalSec=60
+
+WorkingDirectory=/opt/ifconfig.io
+ExecStart=/opt/ifconfig.io/server
+
+PermissionsStartOnly=true
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=web-server
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I was dealing with a CORS issue when I realized it would be really easy to hack your server to dynamically generate a Javascript file that would load an object in the browser and make gaining access to the json data without having to ajax load it easy.

This creates new endpoints for all routes with the suffix `.js`, that changes the content header and spits out an object named `ifconfig_io` with the json attached to it

This is something I found really handy for me and I thought I would share.

Example:
```
ifconfig_io = {"country_code":"","encoding":"gzip, deflate","forwarded":"",
               "ifconfig_hostname":"ifconfig.io","ip":"127.0.0.1","lang":"en-US,en;q=0.5",
               "method":"GET","mime":"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
               "port":57202,"referer":"","ua":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:95.0) Gecko/20100101 Firefox/95.0"}
```